### PR TITLE
fixes typo

### DIFF
--- a/src/gilded_rose/core.clj
+++ b/src/gilded_rose/core.clj
@@ -37,7 +37,7 @@
       (item "+5 Dexterity Vest" 10 20)
       (item "Aged Brie" 2 0)
       (item "Elixir of the Mongoose" 5 7)
-      (item "Sulfuras, Hand of Ragnaros" 0 80)
+      (item "Sulfuras, Hand Of Ragnaros" 0 80)
       (item "Backstage passes to a TAFKAL80ETC concert" 15 20)
     ]]
     (update-quality inventory)


### PR DESCRIPTION
the check in the main method's uses '... Of ...', while the update-current-inventory has '... of ...'
going with what is in the main method :)